### PR TITLE
feat: add 647a2b1d9fd47a43368ebecd dev test profile

### DIFF
--- a/conf/workspace_647a2b1d9fd47a43368ebecd.config
+++ b/conf/workspace_647a2b1d9fd47a43368ebecd.config
@@ -1,0 +1,1 @@
+// TRE specific config

--- a/nextflow.config
+++ b/nextflow.config
@@ -93,6 +93,7 @@ profiles {
     workspace_65a51b13708392a9fbe45799 { includeConfig 'conf/federation_aws_dev_workloads.config' }
     workspace_62c5ca77577efc01458b949b { includeConfig 'conf/workspace_62c5ca77577efc01458b949b.config' }
     workspace_65c658830e01e26a76c53ded { includeConfig 'conf/workspace_65c658830e01e26a76c53ded.config' }
+    workspace_647a2b1d9fd47a43368ebecd { includeConfig 'conf/workspace_647a2b1d9fd47a43368ebecd.config' }
 }
 
 // 3. Process


### PR DESCRIPTION
Adds a new testing profile to check job submission on lifebi-dev environment for:
- workspace: `647a2b1d9fd47a43368ebecd` `azure_wk1`
- organisation `647a22ae11de53c81c1bd348` `lifebit-azure`
- Project `65fd7b36888fac89ab8a3660`
- client `workspace_647a2b1d9fd47a43368ebecd`
- passport-issuer-dev.workspaces `65fd7bde087906b4f1b492c5`

![image](https://github.com/lifebit-ai/mutational-signature-nf/assets/23525618/22b8aca2-a23b-49ef-853b-1aa23a1c0d3c)

📝 `validNames` does not contain `workspace_647a2b1d9fd47a43368ebecd`:
https://github.com/lifebit-ai/nextflow/blob/7e8d2a5ab635b3577e4f6761df62a13863e5c40a/modules/nextflow/src/main/groovy/nextflow/config/ConfigBuilder.groovy#L497-L498

because it not added in https://github.com/lifebit-ai/nextflow/blob/7e8d2a5ab635b3577e4f6761df62a13863e5c40a/modules/nextflow/src/main/groovy/nextflow/config/ConfigParser.groovy#L360-L361